### PR TITLE
체크 박스 - 멀티

### DIFF
--- a/form/src/main/java/hello/itemservice/web/form/FormItemController.java
+++ b/form/src/main/java/hello/itemservice/web/form/FormItemController.java
@@ -9,7 +9,9 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Controller
 @RequestMapping("/form/items")
@@ -42,6 +44,7 @@ public class FormItemController {
     @PostMapping("/add")
     public String addItem(@ModelAttribute Item item, RedirectAttributes redirectAttributes) {
         log.info("item.open={}", item.getOpen());   // item.open=true 면 체크한거 item.open=null이면 체크 안한거
+        log.info("item.regions={}", item.getRegions());
         Item savedItem = itemRepository.save(item);
         redirectAttributes.addAttribute("itemId", savedItem.getId());
         redirectAttributes.addAttribute("status", true);
@@ -57,9 +60,18 @@ public class FormItemController {
 
     @PostMapping("/{itemId}/edit")
     public String edit(@PathVariable Long itemId, @ModelAttribute Item item) {
+        log.info("item.regions={}", item.getRegions());
         itemRepository.update(itemId, item);
         return "redirect:/form/items/{itemId}";
     }
 
+    @ModelAttribute("regions")
+    public Map<String, String> regions() {
+        Map<String, String> regions = new LinkedHashMap<>();
+        regions.put("SEOUL", "서울");
+        regions.put("BUSAN", "부산");
+        regions.put("JEJU", "제주");
+        return regions;
+    }
 }
 

--- a/form/src/main/resources/templates/form/addForm.html
+++ b/form/src/main/resources/templates/form/addForm.html
@@ -54,6 +54,15 @@
             </div>
         </div>
 
+        <!-- multi checkbox -->
+        <div>
+            <div>등록 지역</div>
+            <div th:each="region : ${regions}" class="form-check form-check-inline">
+                <input type="checkbox" th:field="*{regions}" th:value="${region.key}" class="form-check-input">
+                <label th:for="${#ids.prev('regions')}" th:text="${region.value}" class="form-check-label" >서울</label>
+            </div>
+        </div>
+
 
         <div class="row">
             <div class="col">

--- a/form/src/main/resources/templates/form/editForm.html
+++ b/form/src/main/resources/templates/form/editForm.html
@@ -47,6 +47,16 @@
             </div>
         </div>
 
+        <!-- single checkbox -->
+        <div>
+            <div>등록 지역</div>
+            <div th:each="region : ${regions}" class="form-check form-check-inline" >
+                <input type="checkbox" th:field="*{regions}" th:value="${region.key}" class="form-check-input" />
+                <label th:for="${#ids.prev('regions')}" th:text="${region.value}" class="form-check-label" />
+            </div>
+        </div>
+
+
         <div class="row">
             <div class="col">
                 <button class="w-100 btn btn-primary btn-lg" type="submit">저장</button>

--- a/form/src/main/resources/templates/form/item.html
+++ b/form/src/main/resources/templates/form/item.html
@@ -49,6 +49,15 @@
         </div>
     </div>
 
+    <!-- multi checkbox -->
+    <div>
+        <div>등록 지역</div>
+        <div th:each="region : ${regions}" class="form-check form-check-inline">
+            <input type="checkbox" th:field="*{item.regions}" th:value="${region.key}" class="form-check-input" disabled />
+            <label th:for="${#ids.prev('regions')}" th:text="${region.value}" class="form-check-label" >서울</label>
+        </div>
+    </div>
+
     <div class="row">
         <div class="col">
             <button class="w-100 btn btn-primary btn-lg"


### PR DESCRIPTION
- th:for="${#ids.prev('regions')}"
멀티 체크박스는 같은 이름의 여러 체크박스를 만들 수 있다. 그런데 문제는 이렇게 반복해서 HTML 태그를
생성할 때, 생성된 HTML 태그 속성에서 name 은 같아도 되지만, id 는 모두 달라야 한다. 따라서
타임리프는 체크박스를 each 루프 안에서 반복해서 만들 때 임의로 1 , 2 , 3 숫자를 뒤에 붙여준다