### PR TITLE
라디오 버튼

### DIFF
--- a/form/src/main/java/hello/itemservice/web/form/FormItemController.java
+++ b/form/src/main/java/hello/itemservice/web/form/FormItemController.java
@@ -2,6 +2,7 @@ package hello.itemservice.web.form;
 
 import hello.itemservice.domain.item.Item;
 import hello.itemservice.domain.item.ItemRepository;
+import hello.itemservice.domain.item.ItemType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
@@ -45,6 +46,7 @@ public class FormItemController {
     public String addItem(@ModelAttribute Item item, RedirectAttributes redirectAttributes) {
         log.info("item.open={}", item.getOpen());   // item.open=true 면 체크한거 item.open=null이면 체크 안한거
         log.info("item.regions={}", item.getRegions());
+        log.info("item.itemType={}", item.getItemType());
         Item savedItem = itemRepository.save(item);
         redirectAttributes.addAttribute("itemId", savedItem.getId());
         redirectAttributes.addAttribute("status", true);
@@ -72,6 +74,12 @@ public class FormItemController {
         regions.put("BUSAN", "부산");
         regions.put("JEJU", "제주");
         return regions;
+    }
+
+    @ModelAttribute("itemTypes")
+    public ItemType[] itemTypes() {
+
+        return ItemType.values();
     }
 }
 

--- a/form/src/main/resources/templates/form/addForm.html
+++ b/form/src/main/resources/templates/form/addForm.html
@@ -63,6 +63,17 @@
             </div>
         </div>
 
+        <!-- radio button -->
+        <div>
+            <div>상품 종류</div>
+            <div th:each="type : ${itemTypes}" class="form-check form-check-inline">
+                <input type="radio" th:field="*{itemType}" th:value="${type.name()}" class="form-check-input">
+                <label th:for="${#ids.prev('itemType')}" th:text="${type.description}" class="form-check-label">
+                    BOOK
+                </label>
+            </div>
+        </div>
+
 
         <div class="row">
             <div class="col">

--- a/form/src/main/resources/templates/form/editForm.html
+++ b/form/src/main/resources/templates/form/editForm.html
@@ -56,6 +56,27 @@
             </div>
         </div>
 
+        <!-- multi checkbox -->
+        <div>
+            <div>등록 지역</div>
+            <div th:each="region : ${regions}" class="form-check form-check-inline">
+                <input type="checkbox" th:field="${item.regions}" th:value="${region.key}" class="form-check-input">
+                <label th:for="${#ids.prev('regions')}"
+                       th:text="${region.value}" class="form-check-label">서울</label>
+            </div>
+        </div>
+
+        <!-- radio button -->
+        <div>
+            <div>상품 종류</div>
+            <div th:each="type : ${itemTypes}" class="form-check form-check-inline">
+                <input type="radio" th:field="*{itemType}" th:value="${type.name()}" class="form-check-input">
+                <label th:for="${#ids.prev('itemType')}" th:text="${type.description}" class="form-check-label">
+                    BOOK
+                </label>
+            </div>
+        </div>
+
 
         <div class="row">
             <div class="col">

--- a/form/src/main/resources/templates/form/item.html
+++ b/form/src/main/resources/templates/form/item.html
@@ -54,7 +54,18 @@
         <div>등록 지역</div>
         <div th:each="region : ${regions}" class="form-check form-check-inline">
             <input type="checkbox" th:field="*{item.regions}" th:value="${region.key}" class="form-check-input" disabled />
-            <label th:for="${#ids.prev('regions')}" th:text="${region.value}" class="form-check-label" >서울</label>
+            <label th:for="${#ids.prev('regions')}" th:text="${region.value}" class="form-check-label">서울</label>
+        </div>
+    </div>
+
+    <!-- radio button -->
+    <div>
+        <div>상품 종류</div>
+        <div th:each="type : ${itemTypes}" class="form-check form-check-inline">
+            <input type="radio" th:field="${item.itemType}" th:value="${type.name()}" class="form-check-input" disabled>
+            <label th:for="${#ids.prev('itemType')}" th:text="${type.description}" class="form-check-label">
+                BOOK
+            </label>
         </div>
     </div>
 


### PR DESCRIPTION
 - 체크 박스는 수정시 체크를 해제하면 아무 값도 넘어가지 않기 때문에, 별도의 히든 필드로 이런 문제를
해결했다. 라디오 버튼은 이미 선택이 되어 있다면, 수정시에도 항상 하나를 선택하도록 되어 있으므로 체크
박스와 달리 별도의 히든 필드를 사용할 필요가 없다.

- 타임리프에서 ENUM 직접 사용이 가능하지만 이렇게 사용하면 ENUM의 패키지 위치가 변경되거나 할때 자바 컴파일러가 타임리프까지 컴파일오류를 잡을 수 없으므로 추천하지는 않는다.